### PR TITLE
Some fields often include accentuated characters

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from codecs import open
 from setuptools import setup, find_packages
 
@@ -9,11 +10,11 @@ with open('README.rst', encoding='utf-8') as f:
 
 setup(name='pyskel',
       version='0.0.1',
-      description="Skeleton of a Python package",
+      description=u"Skeleton of a Python package",
       long_description=long_description,
       classifiers=[],
       keywords='',
-      author='Sean Gillies',
+      author=u'Sean Gillies',
       author_email='sean@mapbox.com',
       url='https://github.com/mapbox/pyskel',
       license='MIT',


### PR DESCRIPTION
So we should probably label them as unicode. Note that this is
compatible with python 2 and 3.
