### PR TITLE
Don't override standard open function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
-from codecs import open
+from codecs import open as codecs_open
 from setuptools import setup, find_packages
 
 
 # Get the long description from the relevant file
-with open('README.rst', encoding='utf-8') as f:
+with codecs_open('README.rst', encoding='utf-8') as f:
     long_description = f.read()
 
 


### PR DESCRIPTION
Overriding the open function raises a pylint warning.
